### PR TITLE
Add cURL options to skip SSL verification

### DIFF
--- a/src/Mautic/Form.php
+++ b/src/Mautic/Form.php
@@ -66,6 +66,8 @@ class Form
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
         curl_setopt($ch, CURLOPT_VERBOSE, 1);
         curl_setopt($ch, CURLOPT_HEADER, 1);
+        curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 0);
+        curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, 0);
         list($header, $content) = explode("\r\n\r\n", curl_exec($ch), 2);
         $response['header'] = $header;
         $response['content'] = htmlentities($content);

--- a/src/Mautic/Form.php
+++ b/src/Mautic/Form.php
@@ -66,8 +66,10 @@ class Form
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
         curl_setopt($ch, CURLOPT_VERBOSE, 1);
         curl_setopt($ch, CURLOPT_HEADER, 1);
-        curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 0);
-        curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, 0);
+        // Un-comment these two lines if you need to bypass SSL certificate validation
+        // from cURL when it calls  your site
+        //curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 0);
+        //curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, 0);
         list($header, $content) = explode("\r\n\r\n", curl_exec($ch), 2);
         $response['header'] = $header;
         $response['content'] = htmlentities($content);


### PR DESCRIPTION
As I was trying to implement this script, I kept running into the issue of not receiving any response back from the cURL call. The response was blank each time.  I happen to stumble across the solution while looking at the `curl_setopt` parameters.  I was making the call to my dev install of Mautic which has a self-signed SSL which wasn't passing cURL's validation. 

Once I added the two `curl_setopt` to skip SSL validation, everything starting working as intended. I think it would be beneficial to add these two options to prevent other users from having the same issue I did.