### PR TITLE
Allow custom curl opts on the Form::submit method

### DIFF
--- a/src/Mautic/Form.php
+++ b/src/Mautic/Form.php
@@ -34,10 +34,12 @@ class Form
     }
 
     /**
-     * Submit the $data array to the Mautic form
+     * Submit the $data array to the Mautic form, using the optional $curlOpts
+     * array to override curl settings
      * Returns array containing info about the request, response and cookie
      *
      * @param  array  $data
+     * @param  array  $curlOpts
      *
      * @return array
      */

--- a/src/Mautic/Form.php
+++ b/src/Mautic/Form.php
@@ -41,7 +41,7 @@ class Form
      *
      * @return array
      */
-    public function submit(array $data)
+    public function submit(array $data, array $curlOpts = [])
     {
         $originalCookie = $this->mautic->getCookie()->getSuperGlobalCookie();
         $response = [];
@@ -66,6 +66,11 @@ class Form
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
         curl_setopt($ch, CURLOPT_VERBOSE, 1);
         curl_setopt($ch, CURLOPT_HEADER, 1);
+
+        foreach($curlOpts as $key => $value) {
+            curl_setopt($ch, $key, $value);
+        }
+
         list($header, $content) = explode("\r\n\r\n", curl_exec($ch), 2);
         $response['header'] = $header;
         $response['content'] = htmlentities($content);

--- a/src/Mautic/Form.php
+++ b/src/Mautic/Form.php
@@ -67,7 +67,7 @@ class Form
         curl_setopt($ch, CURLOPT_VERBOSE, 1);
         curl_setopt($ch, CURLOPT_HEADER, 1);
 
-        foreach($curlOpts as $key => $value) {
+        foreach ($curlOpts as $key => $value) {
             curl_setopt($ch, $key, $value);
         }
 


### PR DESCRIPTION
I ran into a similar problem as described by @ChgoChad on PR #2 . Perhaps it is a good solution to add the options on the Form::submit method, for including extra curl options that could be used to add/override curl parameters set by the library. This solution adds the option of overriding curl options, without compromising security of default usage.

Example:

```php
$form->submit($data, [CURLOPT_SSL_VERIFYHOST => false]);
```