### PR TITLE
Mautic form fixes

### DIFF
--- a/tests/Mautic/FormTest.php
+++ b/tests/Mautic/FormTest.php
@@ -47,6 +47,44 @@ class FormTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('', $request['data']['mauticform']['return']);
     }
 
+    /**
+     * @dataProvider response_result_provider
+     */
+    function test_prepare_response($result, $expectedHeader, $expectedContentType)
+    {
+        $mautic = new Mautic($this->baseUrl);
+        $formId = 3434;
+        $form = $mautic->getForm($formId);
+
+        $response = $form->prepareResponse($result);
+
+        $this->assertSame($expectedHeader, $response['header']);
+        $this->assertInternalType($expectedContentType, $response['content']);
+    }
+
+    function response_result_provider()
+    {
+        $continue = "HTTP/1.1 100 Continue";
+        $header = "HTTP/1.1 302 Found\r
+Date: Wed, 17 Apr 2019 11:41:44 GMT\r
+Content-Type: text/html; charset=UTF-8\r
+Location: ...";
+        $content = '<html></html>';
+
+        $d = "\r\n\r\n"; // Delimiter between headers and content
+
+        return [
+            // Normal response: headers + content
+            [$header . $d . $content, $header, 'string'],
+
+            // Continue response: 100 Continue + headers + content
+            [$continue . $d . $header . $d . $content, $header, 'string'],
+
+            // cURL returning false because of failure to execute request
+            [false, null, 'null'],
+        ];
+    }
+
     function test_get_url()
     {
         $mautic = new Mautic($this->baseUrl);


### PR DESCRIPTION
I am issuing this pull request to fix several issues:

1. I am sending a big amount of data. What cURL is doing, is setting the `Expect: 100-continue` header (see "[When curl sends 100-continue](https://gms.tf/when-curl-sends-100-continue.html)"). The result of that is that the response is containing two header sections. See below. My proposal would this response
    ```
          'header' => string 'HTTP/1.1 100 Continue' (length=21)
          'content' => string 'HTTP/1.1 302 Found
    Date: Wed, 17 Apr 2019 11:41:44 GMT
    Content-Type: text/html; charset=UTF-8
    Transfer-Encoding: chunked
    Connection: keep-alive
    Set-Cookie: 89f00040d7b0ca501905216bb6d1f780=e11ba72237d8a42fc224c91404a29a42fc237073; path=/; secure; HttpOnly
    Set-Cookie: mautic_session_id=deleted; expires=Thu, 01-Jan-1970 00:00:01 GMT; Max-Age=0; path=/; secure
    Set-Cookie: mautic_device_id=z8abb7jmtwkzvvply0q25v9; expires=Thu, 16-Apr-2020 11:41:44 GMT; Max-Age=31536000; path=/; secure
    [...]
    ```
    Possibly fixing #7? (going out on a limb here :grin:)

2. `curl_exec()` can return a non-string value (such as `false`). My changes would populate the response `'header'` and `'content'` array elements with `null` and if a string response has been returned by `curl_exec()` then it will populate those elements with strings (like the result would be before).
    This prevents the line `list($header, $content) = explode("\r\n\r\n", $result, 2);` from giving a _PHP Notice_ "Undefined offset: 1" as `$result` does not contain `"\r\n\r\n"` and offset 1 cannot be found by `list()` to populate `$content`
    Actually solving #6 

3. The `prepareRequest()` method initialises the `$request` array with the value `['header']` which results in an array element with integer key `0` and value `'header'`. I believe the intent was to initialise the array with an empty headers array: `['header' => []]` as later on this is done: `$request['header'][] = ...` without initialising the `$request['header']` element as an array (is allowed in PHP, but could emit a _PHP Notice_)

_P.S. I see tests fail on files that haven't been touched by my  PR. Can this be fixed or not taken into account with this PR?_